### PR TITLE
fix typo in sample GitHub workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use this bot with [GitHub Actions](https://github.com/features/actions), the 
 ```
 name: PR status label
 
-on
+on:
   pull_request:
     types: ['labeled', 'synchronize']
 


### PR DESCRIPTION
missing a `:` in the example which prevented the action from running correctly.